### PR TITLE
Deprecated attach command, instead of using rpc subcommand

### DIFF
--- a/bin/ubuntu/README.md
+++ b/bin/ubuntu/README.md
@@ -4,13 +4,13 @@ install vite as linux service
 # install v2.10.3-rc3
 
 ```
-curl -s https://raw.githubusercontent.com/vitelabs/gvite/master/bin/ubuntu/install_tar_gz.sh | bash -s v2.10.3-rc3
+curl -s https://raw.githubusercontent.com/vitelabs/go-vite/master/bin/ubuntu/install_tar_gz.sh | bash -s v2.10.3-rc3
 ```
 
 # upgrade to version v2.10.3-rc3
 
 ```
-curl -s https://raw.githubusercontent.com/vitelabs/gvite/master/bin/ubuntu/upgrade_tar_gz.sh | bash -s v2.10.3-rc3
+curl -s https://raw.githubusercontent.com/vitelabs/go-vite/master/bin/ubuntu/upgrade_tar_gz.sh | bash -s v2.10.3-rc3
 ```
 
 # start

--- a/docs/tutorial/node/example.md
+++ b/docs/tutorial/node/example.md
@@ -70,25 +70,11 @@ For example, if you logged in as root user, the installation directory is:
 ```
 
 ## Create Wallet
-
-### Connect Command Line Console
-
-Enter [Installation Directory](./install.md#Description-of-installation-directory) and execute the following command:
-
-  ```bash
-  ./gvite attach ~/.gvite/maindata/gvite.ipc
-  ```
-
-  Below output indicates the full node has been connected successfully:
-  ```
-  Welcome to the Gvite JavaScript console!
-  ->
-  ```
 ### Create a New Wallet  
   
 Execute the following command
 ```javascript
-vite.wallet_newMnemonicAndEntropyStore("123456")
+./gvite rpc ~/.gvite/maindata/gvite.ipc wallet_newMnemonicAndEntropyStore '["123456"]'
 ```
 Here `123456` is keystore's password, you should replace it with your own password.
 
@@ -171,12 +157,9 @@ root      6560  5939  0 12:29 pts/1    00:00:00 grep --color=auto -w gvite
 
 ## Query Current Snapshot Height in Command Line
 
-```bash
-  ./gvite attach ~/.gvite/maindata/gvite.ipc
-```
 Input：
-```javascript
-  vite.ledger_getSnapshotChainHeight();
+```bash
+  ./gvite rpc ~/.gvite/maindata/gvite.ipc ledger_getSnapshotChainHeight
 ```
 Output:
 ```json
@@ -310,42 +293,7 @@ sudo service vite stop
 !!! Gvite service config is located in /etc/vite. Gvite console messages are logged in $HOME/.gvite/std.log.
 
 ## Tips
-
-### Enter gvite Command Line Console via Script
-
-Edit `~/.bashrc`
-
-```bash
-vi ~/.bashrc
-```
-
-Add the following content
-
-```bash
-alias vite="~/vite/gvite attach ~/.gvite/maindata/gvite.ipc"
-```
-Run
-
-```bash
-source ~/.bashrc
-```
-
-Then execute
-
-```bash
-vite
-```
-
-Now you are in gvite command line console. Have fun.
-
-```bash
-INFO[11-15|12:54:38]                                          monitor-log=/root/go-vite/backend-log/backend.log.9104
-this vite node`s git GO version is  7aa4ebc97dfb1d9be4cdd812bd68170b13de59f5
-Welcome to the Gvite JavaScript console!
--> 
-```
-
-### Print Current Snapshot Block Height Constantly
+### Print Current Snapshot Block Height 
 
 Execute below command in gvite command line console
 

--- a/docs/tutorial/node/example.md
+++ b/docs/tutorial/node/example.md
@@ -298,7 +298,7 @@ sudo service vite stop
 Execute below command in gvite command line console
 
 ```bash
-setInterval(function(){vite.ledger_getSnapshotChainHeight();}, 1000)
+./gvite rpc ~/.gvite/maindata/gvite.ipc  ledger_getSnapshotChainHeight
 ```
 
 The latest height will be printed out in every second. Run `exit` to abort.

--- a/docs/tutorial/node/install.md
+++ b/docs/tutorial/node/install.md
@@ -209,16 +209,14 @@ Go 1.11.1 or above version is required. See [Go Installation Guide](https://gola
 
   Linux/Unix:
   ```bash
-  ./gvite attach ~/.gvite/maindata/gvite.ipc
+  ./gvite rpc ~/.gvite/maindata/gvite.ipc ledger_getSnapshotChainHeight
   ```
   Windows:
   ```bash
-  gvite-windows-amd64.exe attach \\.\pipe\gvite.ipc
+  gvite-windows-amd64.exe rpc \\.\pipe\gvite.ipc ledger_getSnapshotChainHeight
   ```
-  Then execute command:
-  ```javascript
-  vite.ledger_getSnapshotChainHeight();
-  ```
+
+  
   The following result will be displayed:
   ```
   "{\"id\":0,\"jsonrpc\":\"2.0\",\"result\":\"51821203\"}"
@@ -229,7 +227,7 @@ Go 1.11.1 or above version is required. See [Go Installation Guide](https://gola
   
 ## Full node rewards
 
-In Vite Pre-Mainnet, rewards will be distributed to full node owners as incentives. 
+In Vite, rewards will be distributed to full node owners as incentives. 
 
 ### Node configuration
 

--- a/docs/tutorial/node/wallet-manage.md
+++ b/docs/tutorial/node/wallet-manage.md
@@ -19,24 +19,11 @@ This document mainly introduces how to config wallet on full node. Before starti
 
 Follow [Full Node Installation][install] to start a full node.
 
-### Connect Full Node in Command Line Console
-
-Navigate to [Full Node Installation Directory][pwd] and execute the following command:
-
-  ```bash
-  ./gvite attach ~/.gvite/maindata/gvite.ipc
-  ```
-
-  Below output indicates the full node has been connected successfully:
-  ```
-  Welcome to the Gvite JavaScript console!
-  ->
-  ```
 ### Create a New Wallet
   
 Execute the following command
 ```javascript
-vite.wallet_createEntropyFile("Your_Password")
+./gvite rpc ~/.gvite/maindata/gvite.ipc wallet_createEntropyFile '["Your_Password"]'
 ```
 This will give you below result
 ```json


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

deprecated attach command, instead of using rpc subcommand.

./gvite rpc [endpoint] '[params]'

for example:
./gvite rpc ~/.gvite/maindata/gvite.ipc ledger_getSnapshotChainHeight
./gvite rpc ~/.gvite/maindata/gvite.ipc wallet_createEntropyFile '["your password"]'


