### PR TITLE
fix(monitoring): Replace unreachable ntp server

### DIFF
--- a/monitor/ntp.go
+++ b/monitor/ntp.go
@@ -21,13 +21,13 @@ var servers = []string{
 	"time6.aliyun.com",
 	"time7.aliyun.com",
 
-	"time1.apple.com",
-	"time2.apple.com",
-	"time3.apple.com",
-	"time4.apple.com",
-	"time5.apple.com",
-	"time6.apple.com",
-	"time7.apple.com",
+	"time.google.com",
+	"time1.google.com",
+	"time2.google.com",
+	"time3.google.com",
+	"time4.google.com",
+	
+	"time.cloudflare.com",
 }
 
 var availIndex = 0


### PR DESCRIPTION
Because apple's time servers are officially not to be used for public projects and are also not accessible, they were exchanged for the servers of Google and Cloudflare.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:


**Other information:**
