### PR TITLE
fix: let fromHeight of 0 mean the latest block instead of the genesis…

### DIFF
--- a/rpcapi/api/filters/subscribe.go
+++ b/rpcapi/api/filters/subscribe.go
@@ -75,6 +75,9 @@ func (s *SubscribeApi) timeoutLoop() {
 type RpcFilterParam struct {
 	AddrRange map[string]*api.Range `json:"addrRange"`
 	Topics    [][]types.Hash        `json:"topics"`
+
+	PageIndex uint64 `json:"pageIndex"`
+	PageSize  uint64 `json:"pageSize"`
 }
 
 type AccountBlock struct {
@@ -720,7 +723,7 @@ func (s *SubscribeApi) createVmLogSubscription(ctx context.Context, rangeMap map
 
 // Deprecated: use ledger_getVmLogsByFilter instead
 func (s *SubscribeApi) GetLogs(param RpcFilterParam) ([]*Logs, error) {
-	logs, err := api.GetLogs(s.vite.Chain(), param.AddrRange, param.Topics)
+	logs, err := api.GetLogs(s.vite.Chain(), param.AddrRange, param.Topics, param.PageIndex, param.PageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/rpcapi/api/ledger_v2.go
+++ b/rpcapi/api/ledger_v2.go
@@ -448,8 +448,8 @@ func GetLogs(c chain.Chain, rangeMap map[string]*Range, topics [][]types.Hash) (
 		if acc == nil {
 			continue
 		}
-		if startHeight == 0 {
-			startHeight = 1
+		if startHeight == 0 || startHeight > acc.Height {
+			startHeight = acc.Height
 		}
 		if endHeight == 0 || endHeight > acc.Height {
 			endHeight = acc.Height


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Current dapps or scripts could break if they assume `startHeight = 0` will return all events since genesis block.
