### PR TITLE
fix: move TestGetHeightPage

### DIFF
--- a/rpcapi/api/ledger_v2_test.go
+++ b/rpcapi/api/ledger_v2_test.go
@@ -1,4 +1,4 @@
-package filters
+package api
 
 import (
 	"testing"
@@ -59,7 +59,7 @@ func TestGetHeightPage(t *testing.T) {
 			if index > len(testCase.resultList)-1 {
 				t.Fatalf("%vth testcase, current index %v, expected finish", i, index)
 			}
-			offset, count, finish := GetHeightPage(startHeight, endHeight, getAccountBlocksCount)
+			offset, count, finish := getHeightPage(startHeight, endHeight, 100)
 			startHeight = offset + 1
 			if result := testCase.resultList[index]; offset != result.offset || count != result.count || finish != result.finish {
 				t.Fatalf("%vth testcase, index %v, expected [%v,%v,%v], got [%v,%v,%v]", i, index, result.offset, result.count, result.finish, offset, count, finish)

--- a/rpcapi/api/tx_test.go
+++ b/rpcapi/api/tx_test.go
@@ -60,14 +60,14 @@ func TestTx_SendRawTx_VerifyHashAndSig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	prevHash, err := types.HexToHash("")
+	prevHash, err := types.HexToHash("0000000000000000000000000000000000000000000000000000000000000000")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	fmt.Printf("zero-tkId %v zero-addr %v\n", zeroTkId, zeroAddr)
 
-	addr, err := types.HexToAddress("vite_ab24ef68b84e642c0ddca06beec81c9acb1977bbd7da27a87a")
+	addr, err := types.HexToAddress("vite_6c1032417f80329f3abe0a024fa3a7aa0e952b0fded2262f6f")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestTx_SendRawTx_VerifyHashAndSig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	privkey, err := ed25519.HexToPrivateKey("")
+	privkey, err := ed25519.HexToPrivateKey("44e9768b7d8320a282e75337df8fc1f12a4f000b9f9906ddb886c6823bb599addfda7318e7824d25aae3c749c1cbd4e72ce9401653c66479554a05a2e3cb4f88")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,6 +88,7 @@ func TestTx_SendRawTx_VerifyHashAndSig(t *testing.T) {
 
 	address := types.PubkeyToAddress(pubKey)
 	if address != addr {
+		fmt.Printf("expected address: %s / actual address: %s\n", addr, address)
 		t.Fatal("publicKey doesn't match address")
 	}
 
@@ -108,6 +109,9 @@ func TestTx_SendRawTx_VerifyHashAndSig(t *testing.T) {
 	}
 
 	hashData := block.ComputeHash()
+	if hashData.IsZero() {
+		t.Fatal("compute hash failed")
+	}
 
 	signData := ed25519.Sign(privkey, hashData.Bytes())
 	signBase64 := base64.StdEncoding.EncodeToString(signData)
@@ -115,17 +119,13 @@ func TestTx_SendRawTx_VerifyHashAndSig(t *testing.T) {
 
 	fmt.Printf("sig=%v\n pub=%v\n hash=%v\n", signBase64, pubKeyBase64, hashData)
 
-	/*	if block.ComputeHash() != hash {
-			t.Fatal("compute hash failed")
-		}
-
-		isVerified, verifyErr := crypto.VerifySig(pubSlice, hash.Bytes(), sigSlice)
-		if verifyErr != nil {
-			t.Fatal(verifyErr)
-		}
-		if !isVerified {
-			t.Fatal("verify hash failed")
-		}*/
+	isVerified, verifyErr := crypto.VerifySig(pubKey, hashData.Bytes(), signData)
+	if verifyErr != nil {
+		t.Fatal(verifyErr)
+	}
+	if !isVerified {
+		t.Fatal("verify hash failed")
+	}
 }
 
 func TestTx_Auto(t *testing.T) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:


**Other information:**
The test `TestGetHeightPage` was not properly updated during the refactoring in this commit: https://github.com/vitelabs/go-vite/commit/5051f001c587d841c61e89214775530522279903 (removed `getAccountBlocksCount` in `rpcapi/api/filters/subscribe.go` but still used in `rpcapi/api/filters/subscribe_test.go`)