### PR TITLE
ci: add dispatch-nightly-build workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,17 @@
+# Workflows
+
+## Create Personal Access Token (PAT):
+
+- Login on GitHub as vitelabs-bot
+- Go to https://github.com/settings/tokens
+- Generate new token
+- Note: WORKFLOW_PUBLIC_REPO
+- Expiration: No expiration
+- Select scopes: repo -> public_repo
+
+## Add repo secret
+
+- Go to Settings -> Secrects -> Actions
+- New repository secret
+- Name: WORKFLOW_PUBLIC_REPO_PAT
+- Value: ghp_...

--- a/.github/workflows/dispatch-nightly-build.yml
+++ b/.github/workflows/dispatch-nightly-build.yml
@@ -1,0 +1,30 @@
+name: dispatch-nightly-build
+
+on:
+  push:
+    branches:    
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Read buildversion
+      id: buildversion
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./version/buildversion
+
+    - name: Echo buildversion
+      # trim buildversion and set environment variable
+      run: echo "${{ steps.buildversion.outputs.content }}" | xargs | echo "buildversion=$(</dev/stdin)" >> $GITHUB_ENV 
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.WORKFLOW_PUBLIC_REPO_PAT }}
+        repository: vitelabs/go-vite-nightly
+        event-type: nightly-build-event
+        client-payload: '{"branch": "master", "tag": "${{ env.buildversion }}"}'


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Improvement
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:


**Other information:**
The added workflow dispatches a `nightly-build-event` on every push to the `master` branch. As a result, the `go-vite-nightly` repository will create a new build by handling the event in a separate workflow. 

> This workflow requires a Personal Access Token (PAT) which is added as repository secret as described in `.github/README.md`