### PR TITLE
Remove privateKey field for rpc address derivation

### DIFF
--- a/rpcapi/api/wallet.go
+++ b/rpcapi/api/wallet.go
@@ -36,9 +36,8 @@ type FindAddrResult struct {
 }
 
 type DeriveResult struct {
-	Bip44Path  string        `json:"bip44Path"`
-	Address    types.Address `json:"address"`
-	PrivateKey []byte        `json:"privateKey"`
+	Bip44Path string        `json:"bip44Path"`
+	Address   types.Address `json:"address"`
 }
 
 type CreateTransferTxParms struct {
@@ -124,15 +123,9 @@ func (m WalletApi) DeriveByFullPath(entropyStore string, fullpath string) (*Deri
 		return nil, err
 	}
 
-	privateKey, err := key.PrivateKey()
-	if err != nil {
-		return nil, err
-	}
-
 	return &DeriveResult{
-		Bip44Path:  fullpath,
-		Address:    *address,
-		PrivateKey: privateKey,
+		Bip44Path: fullpath,
+		Address:   *address,
 	}, nil
 }
 
@@ -151,15 +144,9 @@ func (m WalletApi) DeriveByIndex(entropyStore string, index uint32) (*DeriveResu
 		return nil, err
 	}
 
-	privateKey, err := key.PrivateKey()
-	if err != nil {
-		return nil, err
-	}
-
 	return &DeriveResult{
-		Bip44Path:  path,
-		Address:    *address,
-		PrivateKey: privateKey,
+		Bip44Path: path,
+		Address:   *address,
 	}, nil
 }
 

--- a/rpcapi/api/wallet_v2.go
+++ b/rpcapi/api/wallet_v2.go
@@ -88,15 +88,9 @@ func (m WalletApi) DeriveAddressByIndex(entropyFile string, index uint32) (*Deri
 		return nil, err
 	}
 
-	privateKey, err := key.PrivateKey()
-	if err != nil {
-		return nil, err
-	}
-
 	return &DeriveResult{
-		Bip44Path:  path,
-		Address:    *address,
-		PrivateKey: privateKey,
+		Bip44Path: path,
+		Address:   *address,
 	}, nil
 }
 
@@ -115,15 +109,9 @@ func (m WalletApi) DeriveAddressByPath(entropyFile string, bip44Path string) (*D
 		return nil, err
 	}
 
-	privateKey, err := key.PrivateKey()
-	if err != nil {
-		return nil, err
-	}
-
 	return &DeriveResult{
-		Bip44Path:  bip44Path,
-		Address:    *address,
-		PrivateKey: privateKey,
+		Bip44Path: bip44Path,
+		Address:   *address,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Other, please describe:

security concern

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
`wallet_deriveByFullPath`, `wallet_deriveByIndex`, `wallet_deriveAddressByIndex` and `wallet_deriveAddressByPath` won't return the privateKey of the address anymore for security reasons.

**Other information:**
