### PR TITLE
Enable private rpc api for private modules

### DIFF
--- a/common/default_params.go
+++ b/common/default_params.go
@@ -10,7 +10,6 @@ import (
 const (
 	DefaultHTTPHost = "localhost" // Default host interface for the HTTP RPC server
 	DefaultHTTPPort = 48132       // Default TCP port for the HTTP RPC server
-	DefaultPrivateHTTPPort = 48133// Default TCP port for the private HTTP RPC server
 	DefaultWSHost   = "localhost" // Default host interface for the websocket RPC server
 	DefaultWSPort   = 31420       // Default TCP port for the websocket RPC server
 	DefaultP2PPort  = 8483

--- a/common/default_params.go
+++ b/common/default_params.go
@@ -10,6 +10,7 @@ import (
 const (
 	DefaultHTTPHost = "localhost" // Default host interface for the HTTP RPC server
 	DefaultHTTPPort = 48132       // Default TCP port for the HTTP RPC server
+	DefaultPrivateHTTPPort = 48133// Default TCP port for the private HTTP RPC server
 	DefaultWSHost   = "localhost" // Default host interface for the websocket RPC server
 	DefaultWSPort   = 31420       // Default TCP port for the websocket RPC server
 	DefaultP2PPort  = 8483

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/vitelabs/go-vite/v2/common"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -76,6 +77,7 @@ type Config struct {
 	HttpVirtualHosts []string `json:"HttpVirtualHosts"`
 	WSHost           string   `json:"WSHost"`
 	WSPort           int      `json:"WSPort"`
+	PrivateHttpPort  int      `json:"PrivateHttpPort"`
 
 	HTTPCors            []string `json:"HTTPCors"`
 	WSOrigins           []string `json:"WSOrigins"`
@@ -240,6 +242,13 @@ func (c *Config) WSEndpoint() string {
 		return ""
 	}
 	return fmt.Sprintf("%s:%d", c.WSHost, c.WSPort)
+}
+
+func (c *Config) PrivateHTTPEndpoint() string {
+	if c.PrivateHttpPort == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", common.DefaultHTTPHost, c.PrivateHttpPort)
 }
 
 func (c *Config) SetPrivateKey(privateKey string) {

--- a/node/config/defaults.go
+++ b/node/config/defaults.go
@@ -16,12 +16,13 @@ var DefaultNodeConfig = Config{
 	KeyStoreDir: DefaultDataDir(),
 	HttpPort:    common.DefaultHTTPPort,
 	WSPort:      common.DefaultWSPort,
+	PrivateHttpPort:    common.DefaultPrivateHTTPPort,
 
 	LogLevel:      "info",
 	HTTPCors:      []string{"*"},
 	WSOrigins:     []string{"*"},
-	WSExposeAll:   true,
-	HttpExposeAll: true,
+	WSExposeAll:   false,
+	HttpExposeAll: false,
 
 	Single:          config.DefaultSingle,
 	Identity:        config.DefaultNodeName,

--- a/node/config/defaults.go
+++ b/node/config/defaults.go
@@ -16,7 +16,6 @@ var DefaultNodeConfig = Config{
 	KeyStoreDir: DefaultDataDir(),
 	HttpPort:    common.DefaultHTTPPort,
 	WSPort:      common.DefaultWSPort,
-	PrivateHttpPort:    common.DefaultPrivateHTTPPort,
 
 	LogLevel:      "info",
 	HTTPCors:      []string{"*"},

--- a/node/node.go
+++ b/node/node.go
@@ -54,6 +54,9 @@ type Node struct {
 	httpWhitelist []string
 	httpListener  net.Listener
 	httpHandler   *rpc.Server
+	privateHttpEndpoint  string
+	privateHttpListener  net.Listener
+	privateHttpHandler   *rpc.Server
 
 	wsEndpoint string
 	wsListener net.Listener
@@ -75,6 +78,7 @@ func New(conf *nodeconfig.Config) (*Node, error) {
 		ipcEndpoint:  conf.IPCEndpoint(),
 		httpEndpoint: conf.HTTPEndpoint(),
 		wsEndpoint:   conf.WSEndpoint(),
+		privateHttpEndpoint: conf.PrivateHTTPEndpoint(),
 		stop:         make(chan struct{}),
 	}, nil
 }
@@ -312,7 +316,7 @@ func (node *Node) startRPC() (e error) {
 	}
 
 	if node.config.RPCEnabled {
-		if err := node.startHTTP(node.httpEndpoint, apis, nil, node.config.HTTPCors, node.config.HttpVirtualHosts, rpc.HTTPTimeouts{}, node.config.HttpExposeAll); err != nil {
+		if err := node.startHTTP(node.httpEndpoint, node.privateHttpEndpoint, apis, nil, node.config.HTTPCors, node.config.HttpVirtualHosts, rpc.HTTPTimeouts{}, node.config.HttpExposeAll); err != nil {
 			return err
 		}
 		defer func() {

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -73,8 +73,6 @@ func (node *Node) stopHTTP() {
 	if node.privateHttpListener != nil {
 		node.privateHttpListener.Close()
 		node.privateHttpListener = nil
-
-		log.Info("HTTP endpoint closed", "url", fmt.Sprintf("http://%s", node.httpEndpoint))
 	}
 	if node.privateHttpHandler != nil {
 		node.privateHttpHandler.Stop()

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -37,12 +37,12 @@ func (node *Node) stopIPC() {
 }
 
 // startHTTP initializes and starts the HTTP RPC endpoint.
-func (node *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string, timeouts rpc.HTTPTimeouts, exposeAll bool) error {
+func (node *Node) startHTTP(endpoint string, privateEndpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string, timeouts rpc.HTTPTimeouts, exposeAll bool) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts, timeouts, exposeAll)
+	listener, handler, privateListener, privateHandler, err := rpc.StartHTTPEndpoint(endpoint, privateEndpoint, apis, modules, cors, vhosts, timeouts, exposeAll)
 	if err != nil {
 		return err
 	}
@@ -51,6 +51,8 @@ func (node *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, c
 	node.httpEndpoint = endpoint
 	node.httpListener = listener
 	node.httpHandler = handler
+	node.privateHttpListener = privateListener
+	node.privateHttpHandler = privateHandler
 
 	return nil
 }
@@ -66,6 +68,17 @@ func (node *Node) stopHTTP() {
 	if node.httpHandler != nil {
 		node.httpHandler.Stop()
 		node.httpHandler = nil
+	}
+
+	if node.privateHttpListener != nil {
+		node.privateHttpListener.Close()
+		node.privateHttpListener = nil
+
+		log.Info("HTTP endpoint closed", "url", fmt.Sprintf("http://%s", node.httpEndpoint))
+	}
+	if node.privateHttpHandler != nil {
+		node.privateHttpHandler.Stop()
+		node.privateHttpHandler = nil
 	}
 }
 

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -27,7 +27,7 @@ import (
 )
 
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules
-func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string, timeouts HTTPTimeouts, exposeAll bool) (net.Listener, *Server, error) {
+func StartHTTPEndpoint(endpoint string, privateEndpoint string, apis []API, modules []string, cors []string, vhosts []string, timeouts HTTPTimeouts, exposeAll bool) (net.Listener, *Server, net.Listener, *Server, error) {
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
@@ -35,26 +35,42 @@ func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []str
 	}
 	// Register all the APIs exposed by the services
 	handler := NewServer()
+	privateHandler := NewServer()
+	privateBind := false
 	for _, api := range apis {
 		if exposeAll || whitelist[api.Namespace] || (len(whitelist) == 0 && api.Public) {
 			if err := handler.RegisterName(api.Namespace, api.Service); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, nil, err
 			}
 			log.Debug("HTTP registered", "namespace", api.Namespace)
+		} else if !api.Public {
+			if err := privateHandler.RegisterName(api.Namespace, api.Service); err != nil {
+				return nil, nil, nil, nil, err
+			}
+			privateBind = true
+			log.Debug("Private HTTP API registered", "namespace", api.Namespace)
 		}
 	}
 	// All APIs registered, start the HTTP listener
 	var (
 		listener net.Listener
+		privateListener net.Listener
 		err      error
 	)
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	go NewHTTPServer(cors, vhosts, timeouts, handler).Serve(listener)
 
-	return listener, handler, err
+	if privateBind {
+		if privateListener, err = net.Listen("tcp", privateEndpoint); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		go NewHTTPServer(cors, vhosts, timeouts, privateHandler).Serve(privateListener)
+	}
+
+	return listener, handler, privateListener, privateHandler, err
 }
 
 // StartWSEndpoint starts chain websocket endpoint

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -63,7 +63,7 @@ func StartHTTPEndpoint(endpoint string, privateEndpoint string, apis []API, modu
 
 	go NewHTTPServer(cors, vhosts, timeouts, handler).Serve(listener)
 
-	if privateBind {
+	if privateBind && len(privateEndpoint) > 0 {
 		if privateListener, err = net.Listen("tcp", privateEndpoint); err != nil {
 			return nil, nil, nil, nil, err
 		}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:


**Other information:**
- Add default private api port 48133, which can be configured in "PrivateHttpPort" in node_config.json
- Disable default HttpExposeAll and WsExposeAll
- Move all private modules (if configured, for example, `wallet`) to private HTTP api