### PR TITLE
Fixed "Access is denied." running Mainnet+Testnet

### DIFF
--- a/node/rpc.go
+++ b/node/rpc.go
@@ -12,7 +12,7 @@ func (node *Node) startIPC(apis []rpc.API) error {
 	if node.ipcEndpoint == "" {
 		return nil // IPC disabled.
 	}
-	listener, handler, err := rpc.StartIPCEndpoint(node.ipcEndpoint, apis)
+	listener, handler, err := rpc.StartIPCEndpoint(node.config.NetSelect, node.ipcEndpoint, apis)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Improvement
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

**Other information:**

Fixes "Access is denied." when trying to run Testnet on the same Windows 11 machine as Mainnet. (Two go-vite executables).

The cause of the problem was both executables try to create the same IPC pipe with same name.

The solution was to make sure each executable has it's own pipe name. This is now done by adding the NetSelect string in front of the pipe name followed by an underscore and then the rest of the pipe name.

This should now allow running mainnet and testnet side by side on same machine.

Unfortunately I cannot test it any further, because the testnet seems to be done ? Or at least the seed nodes/json/server is error 404.

I hope this gets fixed so I can run testnet as well, as well as others.

I am not sure what the effect of this could be on other operating systems, not sure if this code is supposed to be cross-platform, this should be tested by others first before applieing this PR.